### PR TITLE
Statically link ocamlformat-rpc

### DIFF
--- a/flakes/ocamlformat/static.diff
+++ b/flakes/ocamlformat/static.diff
@@ -1,5 +1,17 @@
+diff --git a/bin/ocamlformat-rpc/dune b/bin/ocamlformat-rpc/dune
+index f1bda4fa..11e8e369 100644
+--- a/bin/ocamlformat-rpc/dune
++++ b/bin/ocamlformat-rpc/dune
+@@ -13,6 +13,7 @@
+  (name main)
+  (public_name ocamlformat-rpc)
+  (package ocamlformat)
++ (link_flags (:standard -cclib -static))
+  (flags
+   (:standard -open Ocamlformat_stdlib))
+  (instrumentation
 diff --git a/bin/ocamlformat/dune b/bin/ocamlformat/dune
-index 04288971..cf5e13c5 100644
+index 86de53ed..7e0eb858 100644
 --- a/bin/ocamlformat/dune
 +++ b/bin/ocamlformat/dune
 @@ -14,6 +14,7 @@


### PR DESCRIPTION
Fixes a bug where only the ocamlformat binary was being statically linked, not the ocamlformat-rpc binary in the same package.