### PR TITLE
Update ocamlformat packages to fix ocamlformat-rpc bug

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-aarch64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-aarch64-apple-darwin/opam
@@ -21,7 +21,7 @@ authors: [
   "Guillaume Petiot <guillaume@tarides.com>"
   "Jules Aguillon <jules@j3s.fr>"
 ]
-license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 install: [
@@ -29,11 +29,11 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-available: arch = "x86_64" & os = "linux"
+available: arch = "arm64" & os = "macos"
 url {
-  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-10-18.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-10-18.0-x86_64-unknown-linux-musl.tar.gz"
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-07.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-aarch64-apple-darwin.tar.gz"
   checksum: [
-    "sha256=cf98d6ab3f2ba00b13f15984ca450c95ea9d8143376f4c5e866bc72872e1742c"
-    "sha512=27d60a7d6eb87c1957d698417b13647362154ba5fb87a9104eeb2980e356a55593b0c8b02b092d37da34366a53142a0dab038f4f9b10065637b2ddef2568152a"
+    "sha256=b2d355f70515d816669f9001a6ce5e8aaaab9afd04ca6e6d15350bfa2ec8cca6"
+    "sha512=450d5c13b2bb0599e6b39b8ef923da6c66c0d2546e8094f60d4a7d5464dec5f4d27f94e9be13e10c6ea750f7111c137c1c3eca6067ee6e7aecf996fc3c074d57"
   ]
 }

--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-apple-darwin/opam
@@ -21,7 +21,7 @@ authors: [
   "Guillaume Petiot <guillaume@tarides.com>"
   "Jules Aguillon <jules@j3s.fr>"
 ]
-license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 install: [
@@ -29,11 +29,11 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-available: arch = "arm64" & os = "macos"
+available: arch = "x86_64" & os = "macos"
 url {
-  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-10-18.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-10-18.0-aarch64-apple-darwin.tar.gz"
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-07.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-apple-darwin.tar.gz"
   checksum: [
-    "sha256=c52fc74fe87c8625ef4719a62b517b39629702c197c62ebfa31d5cd88952180f"
-    "sha512=cae294ae48fe837520fade2733bdfeb3e0b033bfc5dfc3cffd374d532c9b41a97545f7c49d995c64cda7cea5ba096ca76ceddea3cef2027617f898f59980d18f"
+    "sha256=78b83466b867f84d3d96d9dc8a8e43c841da6f8a68537047940e4abd978c432d"
+    "sha512=2ad7b163fb0af567f7aa212ddeb712f002051d935940588257a7bc22443ede9b8cb8f4927619211fb5f49af8e3cf437b00a45b7709038c1115e520020b843941"
   ]
 }

--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-unknown-linux-musl/opam
@@ -29,11 +29,11 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-available: arch = "x86_64" & os = "macos"
+available: arch = "x86_64" & os = "linux"
 url {
-  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-10-18.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-10-18.0-x86_64-apple-darwin.tar.gz"
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-07.0/ocamlformat.0.26.2+binary-ocaml-5.2.0-built-2024-11-07.0-x86_64-unknown-linux-musl.tar.gz"
   checksum: [
-    "sha256=56af68fb240ebda77d76b76a7f11b8e748125bda234d36a95b0d7b3869b2efc0"
-    "sha512=b380950f6728150aafe69ff983a343248987fb329456fc633fb93455bbe4086489ec2cb005a134d70cc4f6a3e8fa6152f76108e3fd7a451112671cacfc5ef584"
+    "sha256=666f63476f3b2d689302d1dd68f9ded26e1c344e8c618f6bb9766a7176e740eb"
+    "sha512=8a57d9963ad3031065acbcff890fcd40c6f6d2e07f504e03c869743d08e4bf2e732e9f2ff3de880a59ac399cd0be8fce290dcb991cb1d0ed13871cb3950e7418"
   ]
 }


### PR DESCRIPTION
Fixes the bug where ocamlformat-rpc was being dynamically linked.