### PR TITLE
Non flake ocamllsp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-13]
         ocaml: ["5.2.0", "5.1.1"]
         include:
           - os: ubuntu-latest
@@ -70,11 +70,6 @@ jobs:
             ocaml: "5.2.0"
             linking: dynamic
             target_triple: x86_64-apple-darwin
-          - os: macos-14
-            version: "1.19.0"
-            ocaml: "5.2.0"
-            linking: dynamic
-            target_triple: aarch64-apple-darwin
           - os: ubuntu-latest
             version: "1.18.0"
             ocaml: "5.1.1"
@@ -85,11 +80,6 @@ jobs:
             ocaml: "5.1.1"
             linking: dynamic
             target_triple: x86_64-apple-darwin
-          - os: macos-14
-            version: "1.18.0"
-            ocaml: "5.1.1"
-            linking: dynamic
-            target_triple: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 
@@ -115,3 +105,42 @@ jobs:
           allowUpdates: true
           artifacts: "*.tar.gz"
 
+
+  ocaml-lsp-server-build-script:
+    name: Build ocaml-lsp-server binaries from the build script (rather than the flake)
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        os: [macos-14]
+        ocaml: ["5.2.0", "5.1.1"]
+        include:
+          - os: macos-14
+            version: "1.19.0"
+            ocaml: "5.2.0"
+            linking: dynamic
+            target_triple: aarch64-apple-darwin
+          - os: macos-14
+            version: "1.18.0"
+            ocaml: "5.1.1"
+            linking: dynamic
+            target_triple: aarch64-apple-darwin
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set script name
+        run: |
+          echo "BUILD_SCRIPT=./build-scripts/ocaml-lsp-server.${{ matrix.version }}-ocaml.${{ matrix.ocaml }}.sh" >> $GITHUB_ENV
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5
+      - uses: actions/checkout@v4
+      - name: Build ocaml-lsp-server
+        run: |
+          $BUILD_SCRIPT ${{ github.ref_name }} ${{ matrix.target_triple }} $(pwd)
+      - uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: "*.tar.gz"

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -1,0 +1,10 @@
+# Build Scripts
+
+## Why not just use nix?
+
+It's necessary to produce binaries which are statically-linked with muslc as
+they can be used on all distros of linux (including distros that don't link
+with the gnu linker such as alpine and nixos). While it's possible to also
+produce MacOS binaries with the same nix derivations, we found that aarch64
+binaries for MacOS don't work correctly when built with nix due to [this
+issue](https://discuss.ocaml.org/t/corrupted-compiled-interface-after-dune-build/14919).

--- a/build-scripts/ocaml-lsp-server.1.18.0-ocaml.5.1.1.sh
+++ b/build-scripts/ocaml-lsp-server.1.18.0-ocaml.5.1.1.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+TAG=$1
+TARGET=$2
+OUTPUT=$3
+
+OCAML_VERSION=5.1.1
+OCAML_LSP_SERVER_VERSION=1.18.0
+
+TMP_DIR="$(mktemp -d -t ocaml-binary-packages-build.XXXXXXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+opam switch create . "ocaml.$OCAML_VERSION"
+eval "$(opam env)"
+opam install -y "ocaml-lsp-server.$OCAML_LSP_SERVER_VERSION"
+
+ARCHIVE_NAME="ocaml-lsp-server.$OCAML_LSP_SERVER_VERSION+binary-ocaml-$OCAML_VERSION-built-$TAG-$TARGET"
+
+mkdir -p "$ARCHIVE_NAME"
+cp _opam/bin/ocamllsp "$ARCHIVE_NAME"
+cat > "$ARCHIVE_NAME/README.md" <<EOF
+# ocaml-lsp-server binary distribution
+
+See https://github.com/ocaml-dune/ocaml-binary-packages for more information.
+EOF
+tar --format=posix -cvf "$ARCHIVE_NAME.tar" "$ARCHIVE_NAME"
+gzip -9 "$ARCHIVE_NAME.tar"
+mv "$ARCHIVE_NAME.tar.gz" $OUTPUT

--- a/build-scripts/ocaml-lsp-server.1.19.0-ocaml.5.2.0.sh
+++ b/build-scripts/ocaml-lsp-server.1.19.0-ocaml.5.2.0.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+TAG=$1
+TARGET=$2
+OUTPUT=$3
+
+OCAML_VERSION=5.2.0
+OCAML_LSP_SERVER_VERSION=1.19.0
+
+TMP_DIR="$(mktemp -d -t ocaml-binary-packages-build.XXXXXXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+opam switch create . "ocaml.$OCAML_VERSION"
+eval "$(opam env)"
+opam install -y "ocaml-lsp-server.$OCAML_LSP_SERVER_VERSION"
+
+ARCHIVE_NAME="ocaml-lsp-server.$OCAML_LSP_SERVER_VERSION+binary-ocaml-$OCAML_VERSION-built-$TAG-$TARGET"
+
+mkdir -p "$ARCHIVE_NAME"
+cp _opam/bin/ocamllsp "$ARCHIVE_NAME"
+cat > "$ARCHIVE_NAME/README.md" <<EOF
+# ocaml-lsp-server binary distribution
+
+See https://github.com/ocaml-dune/ocaml-binary-packages for more information.
+EOF
+tar --format=posix -cvf "$ARCHIVE_NAME.tar" "$ARCHIVE_NAME"
+gzip -9 "$ARCHIVE_NAME.tar"
+mv "$ARCHIVE_NAME.tar.gz" $OUTPUT


### PR DESCRIPTION
After this change ocamllsp on aarch64 macos will build with opam rather than nix to avoid [this issue](https://discuss.ocaml.org/t/corrupted-compiled-interface-after-dune-build/14919).