### PR TITLE
Release new packages built on 2024-11-21

### DIFF
--- a/packages/ocaml-lsp-server/generate.py
+++ b/packages/ocaml-lsp-server/generate.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+import os
+import tempfile
+import pathlib
+from dataclasses import dataclass, asdict
+from urllib.request import urlretrieve
+from hashlib import file_digest
+
+aarch64_apple_darwin = "aarch64-apple-darwin"
+x86_64_apple_darwin = "x86_64-apple-darwin"
+x86_64_unknown_linux_musl = "x86_64-unknown-linux-musl"
+
+
+@dataclass
+class Version:
+    tag: str
+    source_version: str
+    ocaml_version: str
+    target_triple: str
+
+    def opam_os(self) -> str:
+        if self.target_triple == aarch64_apple_darwin:
+            return "macos"
+        if self.target_triple == x86_64_apple_darwin:
+            return "macos"
+        if self.target_triple == x86_64_unknown_linux_musl:
+            return "linux"
+        raise Exception("unknown target triple: %s" % self.target_triple)
+
+    def opam_arch(self) -> str:
+        if self.target_triple == aarch64_apple_darwin:
+            return "arm64"
+        if self.target_triple == x86_64_apple_darwin:
+            return "x86_64"
+        if self.target_triple == x86_64_unknown_linux_musl:
+            return "x86_64"
+        raise Exception("unknown target triple: %s" % self.target_triple)
+
+    def name(self) -> str:
+        return "ocaml-lsp-server.{source_version}+binary-ocaml-{ocaml_version}-built-{tag}-{target_triple}".format(
+            **asdict(self)
+        )
+
+    def archive_name(self) -> str:
+        return "%s.tar.gz" % self.name()
+
+    def url(self) -> str:
+        return "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/{tag}/{archive_name}".format(
+            tag=self.tag, archive_name=self.archive_name()
+        )
+
+    def url_opam_block(self) -> str:
+        path = os.path.join(tempfile.gettempdir(), self.archive_name())
+        urlretrieve(self.url(), path)
+        with open(path, "rb") as f:
+            sha256 = file_digest(f, "sha256").hexdigest()
+            f.seek(0)
+            sha512 = file_digest(f, "sha512").hexdigest()
+        lines = [
+            "url {",
+            '  src: "%s"' % self.url(),
+            "  checksum: [",
+            '    "sha256=%s"' % sha256,
+            '    "sha512=%s"' % sha512,
+            "  ]",
+            "}",
+        ]
+        return "\n".join(lines)
+
+    def opam_file(self) -> str:
+        return """opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%%{prefix}%%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%%{prefix}%%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "%(opam_arch)s" & os = "%(opam_os)s"
+conflicts: "ocaml" {!= "%(ocaml_version)s"}
+%(url_opam_block)s""" % dict(
+            opam_arch=self.opam_arch(),
+            opam_os=self.opam_os(),
+            ocaml_version=self.ocaml_version,
+            url_opam_block=self.url_opam_block(),
+        )
+
+    def make(self):
+        pathlib.Path(self.name()).mkdir(parents=True, exist_ok=True)
+        with open(os.path.join(self.name(), "opam"), "w") as f:
+            f.write(self.opam_file())
+
+
+versions = [
+    Version(
+        tag="2024-11-21.0",
+        source_version=source_version,
+        ocaml_version=ocaml_version,
+        target_triple=target_triple,
+    )
+    for target_triple in [
+        aarch64_apple_darwin,
+        x86_64_apple_darwin,
+        x86_64_unknown_linux_musl,
+    ]
+    for (source_version, ocaml_version) in [
+        ("1.18.0", "5.1.1"),
+        ("1.19.0", "5.2.0"),
+        ("1.19.0", "5.2.1"),
+    ]
+]
+
+for v in versions:
+    print(v.name())
+    v.make()

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "arm64" & os = "macos"
+conflicts: "ocaml" {!= "5.1.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=8e7982c6e5b2108b9ec513af1d2055a687addb70f37924b665f075eb6cc935aa"
+    "sha512=9190cb3b51db0318862f955f4bcd2e1a31df776e1eca4ac38f548e36ba9e33b133fef752e660501d404d7b6787298195b2ddfb265b2df32644ed1b3b7ceeda77"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.1.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=bd947f445cbb8955fc2c44018b5ec0fe130b2e6c82955eb7ff6a384b34322a8e"
+    "sha512=7cb12d3daa9b4ff0c2c4596bf584f6bc5995e49d82ec34800c69c9974285bdd92bc70f312077827b0af96cfc5d2c29cc10cded8055c6271414309d883df54173"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.1.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"
+  checksum: [
+    "sha256=686c25fd750184740f41fc7472ce6e23503307b894b7187344efc6cbcc25b393"
+    "sha512=3ac2f39ff72dc95588f955127237aed10cf6c88b0d3a00f27ab1e97bc28a30daea8ea6d6a405bc7320f584ffdc5d8887aada1b8ed32aba759dff284577155a88"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-aarch64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-aarch64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "arm64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.0"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-aarch64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=4be9f004617ca32767aceb9bfd852c71195dbce77555a23e739b03ae18c6f3b8"
+    "sha512=75ea8866e2538859ec62ed4ee2c2843836eb721987bf5e0cfd0a9338163a9e4108893d48b15b8a8fe891b45220d2ba1a4b1eb1f75a5740d5411061384a5c9b46"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.0"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=efb6ddc3ad7c6e34387b8a54414b42e83532b079f527107f6858cfce97098874"
+    "sha512=d2b487ffb509fa7b510b1bb1239ab7ee2fecc91c33a784cd196c24381eba658c21a872af556cdbeca8ec5019d44e36581d83ae3aaba340f71e09382e54b9e030"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.0"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"
+  checksum: [
+    "sha256=673683d5b0a6c744116a4930d101457bdbe42d97d462793bf22a48d435cb5b40"
+    "sha512=8be668013c4444a88867ec3677bf1ed31cbadb371626d6fc16ed48eaf56a29b5f42410154ad9976a5b08093d0dfb174e45d317d570243107d719bafa01632e01"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "arm64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=0777c7d543d077c49bb31adbed68019aa86e2419106cb0f9e450d56c3527b02f"
+    "sha512=2b4bc307906f4498ae237d8b2743c45ed17974c2db4474670efa38b362e0e4da43cf2660e77f41b53a05c885912e26eda53681f592270b368ef16296011b8ad3"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=1aac7c9ba95ec95eeacd7df3da0da11fb23a7057a35c33b8046f10e2ced99760"
+    "sha512=f040aa8ac76037b14b18aabd8dc0cdecfb0d5287363b319fc028c72dbc34b77d5142b79bd9f5eda40d22841b147a534fc12033e709f83c5a0cba165dccf483cc"
+  ]
+}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "ocaml-lsp-server"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: "Rudi Grinberg <me@rgrinberg.com>"
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+available: arch = "x86_64" & os = "macos"
+conflicts: "ocaml" {!= "5.2.1"}
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"
+  checksum: [
+    "sha256=1f88dc2a66a3aa8e11c31f6c60c2f1531cb25e89b9ad0588e8f15cafa7219eca"
+    "sha512=efdd86aa444811caf6e105df81086f832074d99736466f89114d529db8b98c6fabccf41a1b74f43ab315dea4d012d1de79b93cd465e5663471b0c211d894038f"
+  ]
+}

--- a/packages/ocamlformat/generate.py
+++ b/packages/ocamlformat/generate.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+import os
+import tempfile
+import pathlib
+from dataclasses import dataclass, asdict
+from urllib.request import urlretrieve
+from hashlib import file_digest
+
+aarch64_apple_darwin = "aarch64-apple-darwin"
+x86_64_apple_darwin = "x86_64-apple-darwin"
+x86_64_unknown_linux_musl = "x86_64-unknown-linux-musl"
+
+
+@dataclass
+class Version:
+    tag: str
+    source_version: str
+    ocaml_version: str
+    target_triple: str
+
+    def opam_os(self) -> str:
+        if self.target_triple == aarch64_apple_darwin:
+            return "macos"
+        if self.target_triple == x86_64_apple_darwin:
+            return "macos"
+        if self.target_triple == x86_64_unknown_linux_musl:
+            return "linux"
+        raise Exception("unknown target triple: %s" % self.target_triple)
+
+    def opam_arch(self) -> str:
+        if self.target_triple == aarch64_apple_darwin:
+            return "arm64"
+        if self.target_triple == x86_64_apple_darwin:
+            return "x86_64"
+        if self.target_triple == x86_64_unknown_linux_musl:
+            return "x86_64"
+        raise Exception("unknown target triple: %s" % self.target_triple)
+
+    def name(self) -> str:
+        return "ocamlformat.{source_version}+binary-ocaml-{ocaml_version}-built-{tag}-{target_triple}".format(
+            **asdict(self)
+        )
+
+    def archive_name(self) -> str:
+        return "%s.tar.gz" % self.name()
+
+    def url(self) -> str:
+        return "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/{tag}/{archive_name}".format(
+            tag=self.tag, archive_name=self.archive_name()
+        )
+
+    def url_opam_block(self) -> str:
+        path = os.path.join(tempfile.gettempdir(), self.archive_name())
+        urlretrieve(self.url(), path)
+        with open(path, "rb") as f:
+            sha256 = file_digest(f, "sha256").hexdigest()
+            f.seek(0)
+            sha512 = file_digest(f, "sha512").hexdigest()
+        lines = [
+            "url {",
+            '  src: "%s"' % self.url(),
+            "  checksum: [",
+            '    "sha256=%s"' % sha256,
+            '    "sha512=%s"' % sha512,
+            "  ]",
+            "}",
+        ]
+        return "\n".join(lines)
+
+    def opam_file(self) -> str:
+        return """opam-version: "2.0"
+name: "ocamlformat"
+version: "%(source_version)s"
+synopsis: "Auto-formatter for OCaml code"
+description: \"""\\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code.\"""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%%{prefix}%%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%%{prefix}%%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "%(opam_arch)s" & os = "%(opam_os)s"
+%(url_opam_block)s""" % dict(
+            source_version=self.source_version,
+            opam_arch=self.opam_arch(),
+            opam_os=self.opam_os(),
+            url_opam_block=self.url_opam_block(),
+        )
+
+    def make(self):
+        pathlib.Path(self.name()).mkdir(parents=True, exist_ok=True)
+        with open(os.path.join(self.name(), "opam"), "w") as f:
+            f.write(self.opam_file())
+
+
+versions = [
+    Version(
+        tag="2024-11-21.0",
+        source_version=source_version,
+        ocaml_version=ocaml_version,
+        target_triple=target_triple,
+    )
+    for target_triple in [
+        aarch64_apple_darwin,
+        x86_64_apple_darwin,
+        x86_64_unknown_linux_musl,
+    ]
+    for (source_version, ocaml_version) in [
+        ("0.26.1", "5.1.1"),
+        ("0.26.2", "5.2.1"),
+    ]
+]
+
+for v in versions:
+    print(v.name())
+    v.make()

--- a/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.1"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "arm64" & os = "macos"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-aarch64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=b9be22d4fb20690fedff754a1e8d107ec23cce21fb93daa70c6b35a0031251f2"
+    "sha512=d65370756afc7cf68df5fbd6c22bf2509ccfb13af65e137542f13c63373ee8419a2161facdc669aebbd129cf03f57bf733431d34f17732bd6a9485c7bbcf0c2d"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.1"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "x86_64" & os = "macos"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=324a774f9794f56aa9118de56d4905954475c12809726a7be3e9c849e7ccb5a4"
+    "sha512=9a04ab051944c44e4e37588c61bc02b2ed0451bf7d088389efa5127963b8e5e72eb19a33c7d0dce9a9ff31129283517b0056a0c0ac4b4e2ed08a1a2dbebaa97f"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.1"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "x86_64" & os = "linux"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.1+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"
+  checksum: [
+    "sha256=6334611f0e7adcace1a69cd7bdc875899b32319d207cec817d4c9b5eb0ad6876"
+    "sha512=030192bccdbb6227ee3c7e53bf5cb3b4f86ee402fbd43348969b487feecd76f5de84f9b25b7e4cde57e3c2f94bd17ba22aaef3c0795aa8f5f4a5af4108de3763"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.2"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "arm64" & os = "macos"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-aarch64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=3b2b2555f7b6b3b27859890d2adbc4c73cc962ecca663a0b25d61ad817c5ed49"
+    "sha512=30e420a1e00fb220754511b5c64e2a6feb5279aa4be840a3f1f0205ac64b62d88a463b812ec841eed547639e368f63c88d8fe3a7e2b8d97d65b1ee33e9ab2427"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.2"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "x86_64" & os = "macos"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-apple-darwin.tar.gz"
+  checksum: [
+    "sha256=76c8459e010e7c7e13eeec09fced09749f203e990d52baf4f3eb7a85b6b35ea0"
+    "sha512=011691371f3bfe259134f52fa6d56d0c49c192872e7f33b8705ee841962864a1257f4eea1c2107efcbd24dd127680fa445920b27b694100e8065983f5c93f405"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+name: "ocamlformat"
+version: "0.26.2"
+synopsis: "Auto-formatter for OCaml code"
+description: """\
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linkiexception"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+install: [
+  [ "find" "." "-type" "d" "-exec" "mkdir" "-p" "%{prefix}%/{}" ";" ]
+  [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+available: arch = "x86_64" & os = "linux"
+url {
+  src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocamlformat.0.26.2+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"
+  checksum: [
+    "sha256=2a811d3b7283e45bedfe872cdaae470560ac3018b0cc54552edff69b949172dc"
+    "sha512=85c61b4a4adfdbee190b7343bd07274acd046d13a85a447b00545dac8f7e2de29ec47a5e8307f76f93f11f8deac85478b162cf784b8daa9202b7e9be97c0038c"
+  ]
+}


### PR DESCRIPTION
This adds new builds of all packages built in docker/shell rather than nix. Also included are some versions of packages built with ocaml.5.2.1. Old builds will be removed in a later change.