### PR TITLE
Fix latest ocaml-lsp-server packages on linux

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -23,7 +23,7 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
-available: arch = "x86_64" & os = "macos"
+available: arch = "x86_64" & os = "linux"
 conflicts: "ocaml" {!= "5.1.1"}
 url {
   src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.18.0+binary-ocaml-5.1.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -23,7 +23,7 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
-available: arch = "x86_64" & os = "macos"
+available: arch = "x86_64" & os = "linux"
 conflicts: "ocaml" {!= "5.2.0"}
 url {
   src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.0-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl/opam
@@ -23,7 +23,7 @@ install: [
   [ "find" "." "-type" "f" "-exec" "cp" "{}" "%{prefix}%/{}" ";" ]
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
-available: arch = "x86_64" & os = "macos"
+available: arch = "x86_64" & os = "linux"
 conflicts: "ocaml" {!= "5.2.1"}
 url {
   src: "https://github.com/ocaml-dune/ocaml-binary-packages/releases/download/2024-11-21.0/ocaml-lsp-server.1.19.0+binary-ocaml-5.2.1-built-2024-11-21.0-x86_64-unknown-linux-musl.tar.gz"


### PR DESCRIPTION
These packages incorrectly required the os to be "macos".